### PR TITLE
Fix Multiple Readback Warning

### DIFF
--- a/src/misc/image-data.js
+++ b/src/misc/image-data.js
@@ -2,7 +2,7 @@ import { DropImageFetchError, DropImageDecodeError } from "./errors.js";
 import { asyncListenEvent } from "./util.js";
 
 const canvas = document.createElement("canvas");
-const canvasCtx = canvas.getContext("2d");
+const canvasCtx = canvas.getContext("2d", { willReadFrequently: true });
 
 canvas.width = 1920;
 canvas.height = 1080;


### PR DESCRIPTION
"Canvas2D: Multiple readback operations using getImageData are faster with the willReadFrequently attribute set to true. See: https://html.spec.whatwg.org/multipage/canvas.html#concept-canvas-will-read-frequently"