### PR TITLE
Add 'startScanning' method to expose externally

### DIFF
--- a/src/components/QrStream.vue
+++ b/src/components/QrStream.vue
@@ -281,6 +281,7 @@ export default defineComponent({
     return {
       ...toRefs(state),
       init,
+      startScanning,
     };
   },
 });


### PR DESCRIPTION
When I obtained the result by scanning the QR code, I presented it on the page and then deleted the result from the page, attempting to scan the same QR code again, but I was unable to obtain the result again.

I have tried the 'init' method, but the dom will be recreated, which is not ideal.

What I am currently doing is to stop scanning after deleting the results (ref. value. stopScanning), and in nextTick (ref. value. startScanning), I can obtain my results.